### PR TITLE
feat(deps): bump tldraw 2 → 5, node 18 → 22, vite 5 → 8, react 18 → 19

### DIFF
--- a/tldraw-sync-backend/Dockerfile
+++ b/tldraw-sync-backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:22-alpine
 
 WORKDIR /app
 

--- a/tldraw-sync-backend/package.json
+++ b/tldraw-sync-backend/package.json
@@ -7,7 +7,7 @@
     "dev": "node --watch server.js"
   },
   "dependencies": {
-    "@tldraw/sync-core": "2.4.6",
+    "@tldraw/sync-core": "^5.0.0",
     "ws": "^8.20.0",
     "unfurl.js": "^6.4.0"
   }

--- a/tldraw/Dockerfile
+++ b/tldraw/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine
+FROM node:22-alpine
 
 WORKDIR /app
 

--- a/tldraw/package.json
+++ b/tldraw/package.json
@@ -8,13 +8,14 @@
     "preview": "vite preview --host 0.0.0.0 --port 3000"
   },
   "dependencies": {
-    "@tldraw/sync": "2.4.6",
-    "@tldraw/tldraw": "2.4.6",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "@tldraw/sync": "^5.0.0",
+    "@tldraw/tldraw": "^5.0.0",
+    "react": "^19.2.6",
+    "react-dom": "^19.2.6"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.0.0",
-    "vite": "^5.0.0"
+    "@vitejs/plugin-react": "^6.0.0",
+    "esbuild": "^0.28.0",
+    "vite": "^8.0.0"
   }
 }

--- a/tldraw/src/main.jsx
+++ b/tldraw/src/main.jsx
@@ -3,18 +3,22 @@ import ReactDOM from 'react-dom/client'
 import { useSync } from '@tldraw/sync'
 import {
     AssetRecordType,
+    atom,
+    computed,
+    createUserId,
     getHashForString,
     getSnapshot,
     loadSnapshot,
     Tldraw,
+    UserRecordType,
     uniqueId,
-    useTldrawUser,
+    useTldrawCurrentUser,
     createTLStore,
     defaultShapeUtils,
     DefaultSizeStyle,
     DefaultFontStyle,
-} from '@tldraw/tldraw'
-import '@tldraw/tldraw/tldraw.css'
+} from 'tldraw'
+import 'tldraw/tldraw.css'
 
 // Get the current protocol and host
 const getBaseUrl = () => {
@@ -66,8 +70,8 @@ const multiplayerAssets = {
                 throw new Error(`Failed to upload asset: ${response.statusText}`)
             }
 
-            // Return just the URL string, not an object
-            return url
+            // tldraw v5: TLAssetStore.upload must return { src, meta? }, not bare URL.
+            return { src: url }
         } catch (error) {
             console.error('Asset upload failed:', error)
             throw error
@@ -327,20 +331,31 @@ function SyncTldraw({ roomId }) {
     
     // No complex activity tracking - keep it simple
 
-    // Create sync store with basic tab visibility info
+    // Create sync store. tldraw v5: `userInfo` and `pingUrl` are gone.
+    // Identity for presence/attribution comes from `users` (a TLUserStore).
     const wsUrl = getWebSocketUrl(roomId)
     console.log('TLDraw sync connecting to:', wsUrl)
-    
+
+    // Bridge React userPreferences state into a tldraw reactive atom so the
+    // TLUserStore's `currentUser` signal recomputes when name/color change.
+    const prefsAtom = React.useRef(atom('userPrefs', userPreferences)).current
+    React.useEffect(() => { prefsAtom.set(userPreferences) }, [prefsAtom, userPreferences])
+
+    const users = React.useMemo(() => ({
+        currentUser: computed('currentUser', () => {
+            const p = prefsAtom.get()
+            return UserRecordType.create({
+                id: createUserId(p.id),
+                name: p.name ?? '',
+                color: p.color ?? undefined,
+            })
+        }),
+    }), [prefsAtom])
+
     const store = useSync({
         uri: wsUrl,
         assets: multiplayerAssets,
-        userInfo: {
-            ...userPreferences,
-            // Only track tab visibility - simple and non-intrusive
-            isTabActive: isTabActive
-        },
-        // Prevent direct HTTP calls by providing explicit URLs
-        pingUrl: `${getBaseUrl()}/tldraw-sync/ping`,
+        users,
     })
 
     // Simple debounced name update - only update state after delay
@@ -357,8 +372,10 @@ function SyncTldraw({ roomId }) {
         []
     )
     
-    // Create user object for Tldraw component with simple debounced name updates
-    const user = useTldrawUser({ 
+    // Create user object for Tldraw component with simple debounced name updates.
+    // v5: useTldrawUser was removed; useTldrawCurrentUser takes the same shape
+    // and returns a TLCurrentUser to pass via the <Tldraw user={...}> prop.
+    const user = useTldrawCurrentUser({
         userPreferences,
         setUserPreferences: (update) => {
             if (typeof update === 'function') {
@@ -398,7 +415,7 @@ function SyncTldraw({ roomId }) {
                     maxImageDimension: 5000,
                     maxAssetSize: 10 * 1024 * 1024, // 10mb
                 }}
-                inferDarkMode
+                colorScheme={userPreferences?.colorScheme ?? 'system'}
                 onMount={(editor) => {
                     editor.registerExternalAssetHandler('url', unfurlBookmarkUrl)
                     // External asset handler registered for URL unfurling
@@ -640,12 +657,12 @@ function LocalTldraw({ roomId }) {
                     maxImageDimension: 5000,
                     maxAssetSize: 10 * 1024 * 1024, // 10mb
                 }}
-                inferDarkMode
+                colorScheme="system"
                 onMount={(editor) => {
                     if (typeof window !== 'undefined') {
                         window.editor = editor
                     }
-                    
+
                     // Set default zoom to 75%
                     setTimeout(() => {
                         try {


### PR DESCRIPTION
Lifts the tldraw stack across three majors (v2 → v3 → v4 → v5) to the latest stable release (**v5.0.0**, 2026-05-06). Ancillary bumps required for the build toolchain to keep up.

## Versions

| Component | Before | After |
|---|---|---|
| `@tldraw/tldraw` | 2.4.6 | **5.0.0** |
| `@tldraw/sync` | 2.4.6 | **5.0.0** |
| `@tldraw/sync-core` | 2.4.6 | **5.0.0** |
| React / React DOM | 18.3.1 | **19.2.6** |
| Vite | 5.x | **8.0.12** |
| `@vitejs/plugin-react` | 4.x | **6.0.1** |
| `esbuild` | (transitive) | **0.28** (now explicit — Vite 8 unbundled it) |
| Node (tldraw Dockerfile) | 18-alpine | **22-alpine** |
| Node (sync-backend Dockerfile) | 20-alpine | **22-alpine** |
| drawio | 30.0.1 (already pinned) | unchanged |
| excalidraw | digest pin (already pinned) | unchanged |

## What needed code changes — and what didn't

### Code-side migration (`tldraw/src/main.jsx`)

v5 split user *preferences* (color, color scheme) from user *identity* (id, name) and removed `useTldrawUser`. Reworked `SyncTldraw` to wire both sides idiomatically.

- Imports: `from '@tldraw/tldraw'` → `from 'tldraw'`; CSS path follows.
- `useTldrawUser` → **`useTldrawCurrentUser`** (same shape; pass returned `TLCurrentUser` as `<Tldraw user={...}>`). Custom debounced `setUserPreferences` logic preserved verbatim.
- New **`users` TLUserStore** for identity. Bridges React `userPreferences` state into a tldraw reactive atom + computed signal so peers see name/color changes in real time. Pattern matches tldraw v5 `templates/simple-server-example`.
- `useSync` options shape: dropped **`userInfo`** (gone in v5) and **`pingUrl`** (never documented; not in v5's `UseSyncOptionsBase`). Added `users`.
- **`TLAssetStore.upload` return shape**: `return url` → `return { src: url }` (this was actually the v3+ shape; the old return-bare-URL worked by accident in v2's lax runtime, would silently corrupt asset records on v3+).
- `<Tldraw inferDarkMode>` → **`<Tldraw colorScheme={...}>`**. SyncTldraw drives this from `userPreferences.colorScheme`; LocalTldraw uses `colorScheme="system"` (no user prefs scope).

### `server.js`: zero changes ✅

`TLSocketRoom`'s `initialSnapshot` / `onDataChange` options were deprecated in v4.3 in favor of pluggable `storage`, but **still work in v5**. Existing JSON-on-disk room persistence preserved as-is — no behavior change for existing rooms, no need for `better-sqlite3` migration. Refactor to `SQLiteSyncStorage` is filed as separate follow-up work.

## Build verification (already passing)

- `npm install` in container: 0 vulnerabilities, no peer-dep conflicts
- `vite build`: clean, 566ms, 1.88 MB JS asset (up from 1.4 MB on v2)
- HEALTHCHECK passes on `tldraw-app` and `tldraw-sync-app`
- All four hub tools return `HTTP 200`: `/`, `/drawio/`, `/excalidraw/`, `/tldraw/`, `/whiteboard/`
- Running containers report `@tldraw/tldraw=5.0.0`, `@tldraw/sync=5.0.0`, `@tldraw/sync-core=5.0.0`, `react=19.2.6`, `node=v22.22.2`

## What still needs in-browser testing before merging

**The full custom-feature checklist is in the comment thread below — please run through it in a browser session before merging.** Build-level verification can't catch UI regressions like color-shortcut DOM hijack still finding the right v5 buttons, sync presence still propagating peer cursors, or the user-preferences modal still binding correctly to the v5 `useTldrawCurrentUser` hook.

## References

- Research basis (v5 migration map): tldraw v5.0.0 release notes, v4.3.0 storage refactor notes, official `templates/simple-server-example`, `apps/examples/src/examples/users/sync-custom-user/`
- ADR rationale (why bump now, why defer SQLiteSyncStorage): see commit body of `f50fa63`

🤖 Generated with [Claude Code](https://claude.com/claude-code)