### PR TITLE
fix(deploy): unblock systemd unit + auto-init submodules on upgrade

### DIFF
--- a/.env
+++ b/.env
@@ -14,6 +14,12 @@ SSL_DOMAIN=localhost
 # TLDraw Configuration
 TLDRAW_DEBUG_PANEL=false
 
+# Optional tldraw v5 license key. Empty (the default) → console warning
+# + small canvas watermark; functionality is unaffected. Free WatermarkOnly
+# keys at https://tldraw.dev/community/license silence the warning.
+# Baked into the bundle at image-build time; rebuild after changing.
+TLDRAW_LICENSE_KEY=
+
 # Production Configuration
 NODE_ENV=production
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,52 @@ For commit-level detail, see the auto-generated body of each
 
 ## [Unreleased]
 
+## [1.4.1] — 2026-05-12
+
+Post-v1.4.0 follow-up: a fictional action version pin had broken the
+Security Scan workflow for every push since the release, and two
+real deployment paths (systemd unit + submodule upgrade) tripped
+users upgrading existing installs. Also exposes the tldraw license
+key as an env var so non-localhost deployments are unblocked.
+
+### Added
+
+- **Optional `TLDRAW_LICENSE_KEY` env var** threaded through to the
+  tldraw bundle at image-build time. Empty (default) keeps the
+  current WatermarkOnly behavior; on `localhost` that's fine, but
+  non-localhost deployments must set this — tldraw v5 blocks the
+  canvas with a license-required overlay otherwise.
+
+### Fixed
+
+- **`aquasecurity/trivy-action@0.28.0`** was a tag that doesn't exist
+  on the upstream action. Security Scan failed to resolve the action
+  on every push since v1.4.0 and blocked every open PR's CI. Bumped
+  to `v0.36.0` along with the other Dependabot-flagged outdated
+  pins (`trufflehog`, `codeql-action`, `upload-artifact`,
+  `setup-node`, `github-script`, `action-gh-release`).
+- **Snyk step in `security.yml`** never ran cleanly. It called
+  `npx snyk test` without first installing tldraw's deps (Snyk
+  errored "Missing node_modules folder") and assumed a `SNYK_TOKEN`
+  secret that isn't configured. Now runs `npm install` first and
+  skips with a workflow notice when the token isn't present.
+- **`drawapp.service`'s `ProtectHome=true`** blocked the docker CLI's
+  access to `/root/.docker/config.json` for registry auth. Changed
+  to `ProtectHome=read-only` and added `/root/.docker` to
+  `ReadWritePaths`.
+- **Submodule auto-init on upgrade.** `git pull` on a pre-v1.4 clone
+  left the whiteboard submodule path unpopulated, breaking the next
+  build. `manage-config.sh` now runs `git submodule update --init
+  --recursive` from every start/rebuild path when an existing
+  submodule directory has no `.git` pointer.
+
+### Changed
+
+- README documents the tldraw v5 license-key requirement for
+  non-localhost deployments with the three options (free
+  WatermarkOnly / trial-commercial / stay on localhost) and the
+  end-to-end flow from `.env` to bundle.
+
 ## [1.4.0] — 2026-05-11
 
 ### Added
@@ -178,5 +224,6 @@ For commit-level detail, see the auto-generated body of each
 
 ---
 
-[Unreleased]: https://github.com/vppillai/diagram-tools-hub/compare/v1.4.0...HEAD
+[Unreleased]: https://github.com/vppillai/diagram-tools-hub/compare/v1.4.1...HEAD
+[1.4.1]: https://github.com/vppillai/diagram-tools-hub/releases/tag/v1.4.1
 [1.4.0]: https://github.com/vppillai/diagram-tools-hub/releases/tag/v1.4.0

--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ cd diagram-tools-hub
 
 Then open https://localhost:8080 in your browser.
 
+> 📜 **TLDraw needs a license key for non-localhost deployments.** On
+> `localhost` and `127.0.0.1` the canvas works without a key (just a
+> small corner watermark + console warning). On any other hostname
+> (LAN address, internal DNS, public URL) tldraw v5 blocks the canvas
+> with a license-required overlay. Get a free WatermarkOnly key at
+> https://tldraw.dev/community/license, drop it into `.env` as
+> `TLDRAW_LICENSE_KEY=…`, and rebuild the tldraw container — see the
+> "TLDraw Licensing" section below for details.
+
 ## Access Points
 
 - **Main Hub**: https://localhost:8080 (or configured HTTPS_PORT)
@@ -211,6 +220,45 @@ TLDraw features a powerful WebSocket-based collaboration system supporting multi
 - **Storage**: File-based persistence in `.rooms` and `.assets` directories
 - **Monitoring**: REST API endpoints for room statistics and health checks
 
+### TLDraw Licensing
+
+tldraw v5 enforces a client-side license check that escalates by
+hostname:
+
+| Hostname              | Without `TLDRAW_LICENSE_KEY`                            |
+|-----------------------|---------------------------------------------------------|
+| `localhost`, `127.0.0.1` | Canvas renders normally; small corner watermark + console warning |
+| Any other hostname    | Canvas is blocked with a license-required overlay       |
+
+Three options to satisfy the check:
+
+1. **Free WatermarkOnly license** *(recommended for personal / OSS use)* —
+   request via the form at
+   [tldraw.dev/community/license](https://tldraw.dev/community/license).
+   tldraw emails you a key. The small corner watermark stays; the
+   blocking overlay and console warning go away.
+2. **Trial / commercial license** — contact sales@tldraw.com. No watermark.
+3. **Stay on localhost** — for purely local development the warning is
+   cosmetic; no key needed.
+
+Once you have a key, set it in `.env`:
+
+```bash
+TLDRAW_LICENSE_KEY=<paste-key-here>
+```
+
+Then rebuild the tldraw container — the key is baked into the bundle
+at build time:
+
+```bash
+./manage-config.sh rebuild tldraw
+```
+
+The key flows from `.env` → docker-compose `build.args` →
+`ARG VITE_TLDRAW_LICENSE_KEY` in `tldraw/Dockerfile` → Vite reads it
+at build time via `import.meta.env.VITE_TLDRAW_LICENSE_KEY`. An empty
+value is treated the same as omitting the prop.
+
 ### Monitoring & Analytics
 
 The TLDraw system includes comprehensive monitoring capabilities:
@@ -247,6 +295,7 @@ SSL_DOMAIN=localhost                # SSL certificate domain
 
 # TLDraw Settings
 TLDRAW_DEBUG_PANEL=true             # TLDraw debug panel (enabled)
+TLDRAW_LICENSE_KEY=                 # see "TLDraw licensing" below; required for non-localhost deploys
 
 # Application Settings
 NODE_ENV=production                 # Node.js environment

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ cd diagram-tools-hub
 ```
 
 > `--recurse-submodules` initializes the [whiteboard](https://github.com/vppillai/whiteboard) submodule (pinned to a release tag). If you cloned without it, run `git submodule update --init --recursive` from inside the repo before starting services.
+>
+> **Upgrading an existing clone:** `git pull` does not initialize newly-added submodules. `manage-config.sh start` (and `rebuild`) now auto-init missing submodules before building, so the upgrade path is `git pull && ./manage-config.sh rebuild`. If you'd rather do it explicitly: `git submodule update --init --recursive`.
 
 **Development Mode:**
 ```bash

--- a/drawapp.service
+++ b/drawapp.service
@@ -21,12 +21,17 @@ RestartSec=10
 Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 Environment=DOCKER_COMPOSE_IGNORE_ORPHANS=1
 
-# Security settings
+# Security settings.
+# ProtectHome is read-only (not full true) because the service runs as
+# root and calls `docker compose …`, which reads /root/.docker/config.json
+# for registry auth; full ProtectHome masks /root entirely and the docker
+# CLI errors out. /root/.docker is added to ReadWritePaths so credential
+# helpers' caches under it remain writable.
 NoNewPrivileges=true
 PrivateTmp=true
 ProtectSystem=strict
-ProtectHome=true
-ReadWritePaths=/path/to/drawApp
+ProtectHome=read-only
+ReadWritePaths=/path/to/drawApp /root/.docker
 
 [Install]
 WantedBy=multi-user.target 

--- a/manage-config.sh
+++ b/manage-config.sh
@@ -724,6 +724,8 @@ services:
     build:
       context: ./tldraw
       dockerfile: Dockerfile
+      args:
+        VITE_TLDRAW_LICENSE_KEY: \${TLDRAW_LICENSE_KEY:-}
     container_name: tldraw-app
     restart: unless-stopped
 
@@ -806,6 +808,8 @@ services:
     build:
       context: ./tldraw
       dockerfile: Dockerfile
+      args:
+        VITE_TLDRAW_LICENSE_KEY: \${TLDRAW_LICENSE_KEY:-}
     container_name: tldraw-app
     restart: unless-stopped
 

--- a/manage-config.sh
+++ b/manage-config.sh
@@ -26,6 +26,32 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
+# If `.gitmodules` declares submodules but the working tree has them
+# unpopulated (the classic "I upgraded from an older release with
+# `git pull` and the new whiteboard service builds with an empty
+# context" trap), initialize them. Called from every start/rebuild
+# entry point so existing installs upgrade cleanly without the user
+# having to remember `git submodule update --init --recursive`.
+ensure_submodules() {
+    [ -f .gitmodules ] || return 0
+    command -v git >/dev/null 2>&1 || return 0
+
+    # A submodule path that exists but has no .git pointer is unpopulated.
+    local needs_init=0
+    while IFS= read -r path; do
+        [ -n "$path" ] || continue
+        if [ -d "$path" ] && [ ! -e "$path/.git" ]; then
+            needs_init=1
+            break
+        fi
+    done < <(git config -f .gitmodules --get-regexp 'submodule\..*\.path' | awk '{print $2}')
+
+    if [ "$needs_init" = "1" ]; then
+        echo -e "${BLUE}[INFO]${NC} Initializing git submodules (whiteboard, …)…"
+        git submodule update --init --recursive
+    fi
+}
+
 # Logging functions
 log_info() {
     echo -e "${BLUE}[INFO]${NC} $1"
@@ -121,10 +147,10 @@ show_config() {
 start_services() {
     local cert_file="$2"
     local key_file="$3"
-    
-    # Handle SSL setup automatically
+
+    ensure_submodules
     setup_ssl_auto "$cert_file" "$key_file"
-    
+
     log_info "Starting all services..."
     
     # Stop any existing containers first to avoid conflicts
@@ -156,10 +182,10 @@ start_services() {
 start_dev_services() {
     local cert_file="$2"
     local key_file="$3"
-    
-    # Handle SSL setup automatically
+
+    ensure_submodules
     setup_ssl_auto "$cert_file" "$key_file"
-    
+
     log_info "Starting all services in development mode..."
     log_warning "Development mode: TLDraw will have hot-reload enabled and serve from source"
     
@@ -253,6 +279,7 @@ rebuild_services() {
     local key_file="$4"
     
     if [ -n "$service" ]; then
+        ensure_submodules
         log_info "Rebuilding and restarting $service service..."
         sudo docker compose build --no-cache "$service"
         sudo docker compose up -d "$service"
@@ -261,13 +288,11 @@ rebuild_services() {
     else
         log_info "Rebuilding and restarting all services..."
         sudo docker compose down
-        
-        # Handle SSL setup automatically
+
+        ensure_submodules
         setup_ssl_auto "$cert_file" "$key_file"
-        
-        # Ensure all configuration files exist
         ensure_configs_exist
-        
+
         sudo docker compose build --no-cache
         sudo docker compose up -d
         log_success "All services rebuilt and started successfully!"
@@ -296,6 +321,7 @@ rebuild_dev_services() {
     local key_file="$4"
     
     if [ -n "$service" ]; then
+        ensure_submodules
         log_info "Rebuilding and restarting $service service in development mode..."
         sudo docker compose -f docker-compose.yml -f docker-compose.dev.yml build --no-cache "$service"
         sudo docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d "$service"
@@ -305,13 +331,11 @@ rebuild_dev_services() {
         log_info "Rebuilding and restarting all services in development mode..."
         log_warning "Development mode: TLDraw will have hot-reload enabled and serve from source"
         sudo docker compose down
-        
-        # Handle SSL setup automatically
+
+        ensure_submodules
         setup_ssl_auto "$cert_file" "$key_file"
-        
-        # Ensure all configuration files exist
         ensure_configs_exist
-        
+
         sudo docker compose -f docker-compose.yml -f docker-compose.dev.yml build --no-cache
         sudo docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
         log_success "All services rebuilt and started successfully in development mode!"
@@ -382,15 +406,13 @@ clean_rebuild() {
     echo
     if [[ $REPLY =~ ^[Yy]$ ]]; then
         log_info "Performing complete clean and rebuild..."
-        
-        # Clean everything
+
         sudo docker compose down --remove-orphans --volumes --rmi all
         sudo docker system prune -a -f --volumes
-        
-        # Ensure all configuration files exist before rebuild
+
+        ensure_submodules
         ensure_configs_exist
-        
-        # Rebuild from scratch
+
         sudo docker compose build --no-cache
         sudo docker compose up -d
         
@@ -973,7 +995,7 @@ install_service() {
         -e "s|ExecStart=.*|ExecStart=$current_dir/manage-config.sh start|g" \
         -e "s|ExecStop=.*|ExecStop=$current_dir/manage-config.sh stop|g" \
         -e "s|ExecReload=.*|ExecReload=$current_dir/manage-config.sh restart|g" \
-        -e "s|ReadWritePaths=.*|ReadWritePaths=$current_dir|g" \
+        -e "s|ReadWritePaths=.*|ReadWritePaths=$current_dir /root/.docker|g" \
         "$service_file" > "$rendered"
 
     log_info "Copying service file to $systemd_dir..."

--- a/tldraw/Dockerfile
+++ b/tldraw/Dockerfile
@@ -26,6 +26,13 @@ WORKDIR /app
 COPY package.json ./
 RUN npm install --no-audit --no-fund
 
+# Optional tldraw license key. Vite reads VITE_-prefixed env vars at build
+# time and substitutes them into the bundle. Empty → unset behavior
+# (WatermarkOnly + console warning). docker-compose forwards
+# $TLDRAW_LICENSE_KEY from .env to this build arg.
+ARG VITE_TLDRAW_LICENSE_KEY=""
+ENV VITE_TLDRAW_LICENSE_KEY=$VITE_TLDRAW_LICENSE_KEY
+
 COPY index.html vite.config.js ./
 COPY src ./src
 RUN npm run build

--- a/tldraw/src/main.jsx
+++ b/tldraw/src/main.jsx
@@ -45,6 +45,15 @@ const getWebSocketUrl = (roomId) => {
     return wsUrl
 }
 
+// tldraw v5 introduced a license check that logs a console warning and
+// shows a small corner watermark when no `licenseKey` prop is set. The
+// canvas still works without one. For an optional silenced experience,
+// drop a free WatermarkOnly key (https://tldraw.dev/community/license)
+// or a commercial key into TLDRAW_LICENSE_KEY in .env and rebuild —
+// Vite picks it up via the VITE_-prefixed build-time env var below.
+// Empty or unset → undefined, which is the same as omitting the prop.
+const TLDRAW_LICENSE_KEY = import.meta.env.VITE_TLDRAW_LICENSE_KEY || undefined
+
 // Generate room ID from URL path, return null if no room specified
 const getRoomId = () => {
     const path = window.location.pathname
@@ -890,6 +899,7 @@ function SyncTldraw({ roomId }) {
             <Tldraw
                 store={store}
                 user={user}
+                licenseKey={TLDRAW_LICENSE_KEY}
                 components={TLDRAW_COMPONENTS}
                 options={{
                     maxImageDimension: 5000,
@@ -946,6 +956,7 @@ function LocalTldraw() {
     return (
         <Tldraw
             store={store}
+            licenseKey={TLDRAW_LICENSE_KEY}
             components={TLDRAW_COMPONENTS}
             options={{
                 maxImageDimension: 5000,


### PR DESCRIPTION
## Summary

Two issues surfaced when upgrading an existing diagram-tools-hub install to v1.4.0:

1. **`drawapp.service` ProtectHome=true blocked Docker.** The unit runs as root and calls `docker compose …`, which reads `/root/.docker/config.json` for registry auth. Full ProtectHome masks `/root` and docker errors out.
   - Changed to `ProtectHome=read-only`.
   - Added `/root/.docker` to `ReadWritePaths` so credential-helper caches still work.
   - Updated `install_service`'s sed substitution to keep `/root/.docker` in the rendered path.

2. **Whiteboard submodule wasn't auto-initialized on upgrade.** `git pull` on a pre-v1.4 clone leaves `./whiteboard/` empty, then `docker compose build whiteboard` fails with empty-context.
   - Added `ensure_submodules` helper to `manage-config.sh`. Fires from every start / rebuild entry point. No-op on already-populated submodules.
   - README quick-start has an explicit "Upgrading an existing clone" callout.

Both reported by @vppillai during a production upgrade.

## Test plan

- [ ] CI green (build-test + security-scan)
- [ ] On a fresh clone with `--recurse-submodules`: `./manage-config.sh start` works (regression check)
- [ ] On a clone WITHOUT `--recurse-submodules`: `./manage-config.sh start` auto-inits submodule before build
- [ ] `sudo ./manage-config.sh install-service` produces a `/etc/systemd/system/drawapp.service` with `ProtectHome=read-only` and `ReadWritePaths=<repo> /root/.docker`
- [ ] `systemctl start drawapp` no longer errors on `/root/.docker` access