### PR TITLE
fix(deploy): always regenerate generated configs on rebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ For commit-level detail, see the auto-generated body of each
 
 ## [Unreleased]
 
+## [1.4.2] — 2026-05-12
+
+Single-fix patch closing a release-upgrade trap surfaced by a user
+upgrading v1.4.0 → v1.4.1.
+
+### Fixed
+
+- **`manage-config.sh rebuild <service>` now picks up template
+  changes after a release upgrade.** Both `docker-compose.yml` and
+  `engine/nginx.conf` are gitignored artifacts of the script's
+  in-file templates. The previous `ensure_configs_exist` ran
+  `if [ ! -f … ]; then create_…`, which left stale files in place
+  whenever the upgrade-from version had already bootstrapped them.
+  Concrete repro: v1.4.1's compose template added a
+  `VITE_TLDRAW_LICENSE_KEY` build arg under the tldraw service;
+  `./manage-config.sh rebuild tldraw` against an upgraded checkout
+  rebuilt the image against the stale v1.4.0 compose file, the new
+  build arg never reached docker build, and the license key in
+  `.env` never made it into the bundle. `ensure_configs_exist`
+  now always regenerates from templates, and all three rebuild
+  paths (`rebuild_services` single-service, `rebuild_dev_services`
+  single-service, `rebuild_only`) call it before building.
+
 ## [1.4.1] — 2026-05-12
 
 Post-v1.4.0 follow-up: a fictional action version pin had broken the
@@ -224,6 +247,7 @@ key as an env var so non-localhost deployments are unblocked.
 
 ---
 
-[Unreleased]: https://github.com/vppillai/diagram-tools-hub/compare/v1.4.1...HEAD
+[Unreleased]: https://github.com/vppillai/diagram-tools-hub/compare/v1.4.2...HEAD
+[1.4.2]: https://github.com/vppillai/diagram-tools-hub/releases/tag/v1.4.2
 [1.4.1]: https://github.com/vppillai/diagram-tools-hub/releases/tag/v1.4.1
 [1.4.0]: https://github.com/vppillai/diagram-tools-hub/releases/tag/v1.4.0

--- a/manage-config.sh
+++ b/manage-config.sh
@@ -280,6 +280,14 @@ rebuild_services() {
     
     if [ -n "$service" ]; then
         ensure_submodules
+        # Regenerate docker-compose.yml (and nginx.conf) from the script's
+        # templates BEFORE the build, even on single-service rebuilds.
+        # docker-compose.yml is gitignored / generated, so a user who has
+        # upgraded across a release whose template changed (e.g. a new
+        # build arg was added to a service definition) would otherwise
+        # rebuild against the stale on-disk compose file and never pick
+        # up the new template content.
+        ensure_configs_exist
         log_info "Rebuilding and restarting $service service..."
         sudo docker compose build --no-cache "$service"
         sudo docker compose up -d "$service"
@@ -322,6 +330,9 @@ rebuild_dev_services() {
     
     if [ -n "$service" ]; then
         ensure_submodules
+        # Regenerate the compose file before single-service dev rebuild
+        # — same reasoning as `rebuild_services`. See the comment there.
+        ensure_configs_exist
         log_info "Rebuilding and restarting $service service in development mode..."
         sudo docker compose -f docker-compose.yml -f docker-compose.dev.yml build --no-cache "$service"
         sudo docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d "$service"
@@ -370,6 +381,10 @@ rebuild_only() {
         exit 1
     fi
     
+    # Regenerate the compose file before building — see rebuild_services
+    # for why. Without this, `rebuild-only` against an upgraded checkout
+    # silently builds against a stale compose template.
+    ensure_configs_exist
     log_info "Rebuilding $service service without restarting..."
     sudo docker compose build --no-cache "$service"
     log_success "$service service rebuilt successfully! Use 'restart $service' to apply changes."
@@ -846,28 +861,27 @@ EOF
 }
 
 ensure_configs_exist() {
-    log_info "Ensuring all configuration files exist..."
-    
-    # Check if nginx.conf exists
-    if [ ! -f "./engine/nginx.conf" ]; then
-        log_info "nginx.conf not found, creating configuration..."
-        if [ -f "./certs/cert.pem" ] && [ -f "./certs/key.pem" ]; then
-            create_https_nginx_config
-        else
-            create_http_only_config
-        fi
+    # Always regenerate the generated configs from the in-script templates.
+    # docker-compose.yml and engine/nginx.conf are both gitignored — they
+    # are pure artifacts of `manage-config.sh`'s templates. The previous
+    # version of this function ran `if [ ! -f ... ]; then create_…` which
+    # left stale files in place after an upgrade. Specifically: a user
+    # upgrading v1.4.0 → v1.4.1 hit this — v1.4.1 added a build arg to the
+    # tldraw service in the template, but `rebuild` reused the v1.4.0
+    # compose file on disk and the new arg never reached docker build.
+    # Always regenerating fixes the class of problem.
+    log_info "Regenerating engine/nginx.conf and docker-compose.yml from templates..."
+
+    if [ -f "./certs/cert.pem" ] && [ -f "./certs/key.pem" ]; then
+        create_https_nginx_config
+        update_docker_compose_https
+    else
+        create_http_only_config
+        create_http_only_docker_compose
     fi
-    
-    # Check if docker-compose.yml exists or needs regeneration
-    if [ ! -f "./docker-compose.yml" ]; then
-        log_error "docker-compose.yml not found. This file should exist in the project."
-        exit 1
-    fi
-    
-    # Ensure environment variables are used in compose file
+
     ensure_env_variables_in_compose
-    
-    log_info "Configuration files validated."
+    log_info "Configuration files regenerated."
 }
 
 ensure_env_variables_in_compose() {


### PR DESCRIPTION
## Summary

Closes a deployment trap discovered upgrading v1.4.0 → v1.4.1:

> The license key in \`.env\` was correctly read, but \`./manage-config.sh rebuild tldraw\` reused the stale v1.4.0 \`docker-compose.yml\` on disk — which lacked the new \`VITE_TLDRAW_LICENSE_KEY\` build arg added in v1.4.1's template. The build arg never reached docker build, the key never made it into the bundle. A full stop+start cycle worked because that path goes through \`setup_ssl_auto\` → \`enable_https_config\` which does regenerate the compose file.

## Fix

1. **\`ensure_configs_exist\` now ALWAYS regenerates** \`docker-compose.yml\` and \`engine/nginx.conf\` from the in-script templates instead of only creating them when missing. Both files are gitignored — they're pure artifacts of the script's templates, with no expectation of preservation.
2. **All three rebuild paths** (\`rebuild_services\` single-service, \`rebuild_dev_services\` single-service, \`rebuild_only\`) now call \`ensure_configs_exist\` before building. The "rebuild all" paths already did this via \`setup_ssl_auto\`'s chain.

## Test plan

- [x] **Manual repro**: corrupted local \`docker-compose.yml\` to remove the \`VITE_TLDRAW_LICENSE_KEY\` args block (mimicking v1.4.0's compose file). Ran \`./manage-config.sh rebuild-only tldraw\`. Compose file was regenerated with the args block restored.
- [ ] CI build-test + security-scan green.