### PR TITLE
release: v1.6.0 — bump whiteboard submodule v1.3.0 → v1.4.2

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,21 @@ SSL_DOMAIN=localhost
 # Set to 'true' to enable the debug panel in tldraw
 TLDRAW_DEBUG_PANEL=false
 
+# TLDraw v5 license key. REQUIRED for deployments on any hostname OTHER
+# than `localhost` / `127.0.0.1` — on those two the canvas works
+# without a key (small corner watermark + console warning). On any
+# other hostname (LAN IP, internal DNS, public URL) tldraw v5 blocks
+# the canvas with a license-required overlay until a key is supplied.
+#
+# Get a free WatermarkOnly key at https://tldraw.dev/community/license
+# (recommended for personal / OSS use). The watermark stays but the
+# blocking overlay goes away. For watermark-free deployments contact
+# sales@tldraw.com. See README.md → "TLDraw Licensing" for details.
+#
+# The key is baked into the tldraw bundle at build time; after setting
+# it here run `./manage-config.sh rebuild tldraw` to apply.
+# TLDRAW_LICENSE_KEY=
+
 # Development Configuration
 NODE_ENV=production
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ For commit-level detail, see the auto-generated body of each
 
 ## [Unreleased]
 
+## [1.6.0] — 2026-05-14
+
+Submodule bump — picks up whiteboard `v1.3.0` → `v1.4.2`. The bundled `/whiteboard/` instance gains the v1.4 Shape tool (rectangle / ellipse / line / arrow), a comprehensive right-click menu overhaul (icon-only pills with hover tooltips, shared swatch palette with custom-color "+" and ×-delete, pinned-menu persistence across sessions), a Factory Reset button in the settings panel (recovery from stuck IDB / service-worker states), plus two follow-up patches (empty-text guard, factory-reset URL cleanup). DTH proper is unchanged: same services, same networking, same env contract.
+
+### Changed
+
+- **Whiteboard submodule bumped to [v1.4.2](https://github.com/vppillai/whiteboard/releases/tag/v1.4.2).** Users of the bundled `/whiteboard/` instance gain:
+
+  **From whiteboard v1.4.0:**
+  - **Shape tool** — drag-to-create rectangle / ellipse / line / arrow. One unified tool with four sub-modes (`R` / `O` / `A` / `L`); Shift constrains (square / circle / 45° lines). Sticky color, stroke width, fill toggle, fill-opacity slider. Lines and arrows use endpoint-based resize so dragging past origin flips direction naturally. Round-trips through clipboard + PNG / SVG / PDF exports as native vector primitives.
+  - **Right-click menu overhaul** — icon-only pills with hover tooltips revealing the name + shortcut. Tool row split into two rows of three. Shared swatch palette (curated colors + custom + "+") across every COLOR section. Hover-revealed × badge deletes custom swatches inline. Pinned menu persists across browser sessions (localStorage), survives Esc, auto-rebuilds when settings change, and auto-reappears at its anchor on page refresh. Tool / selection / settings changes broadcast to the pinned menu's contextual section.
+  - **Factory Reset** — destructive recovery in the settings panel that wipes all per-origin browser state (IndexedDB, localStorage, caches, service workers) and reloads. Replaces the DevTools-console snippet that was the previous recovery path for stuck states (multi-tab IDB-upgrade blocks, stale service workers).
+  - **Block-eraser scope** — wipe mode remains strokes-only (pixel-cut); object mode tap deletes any kind (strokes / shapes / texts / images). Prevents the prior "erasing strokes off an image also nukes the image" footgun.
+  - **Fine-grained text size** — `Cmd/Ctrl+Shift+,` / `Cmd/Ctrl+Shift+.` decrement / increment the active text's font size by 1 px. Works in both edit mode and Select mode.
+  - **Keymap rebinds** — `R` / `O` / `A` / `L` activate the Shape tool sub-modes; `P` is laser pointer (was `L`); `Shift+P` is pen-default brush (was `P`); `Shift+C` opens the color picker (was `C`); `Shift+O` opens the options menu (was `O`).
+
+  **From whiteboard v1.4.1:**
+  - **Empty-text guard** — whitespace-only text objects no longer get persisted; pressing Esc on an empty new-text discards instead of saving.
+
+  **From whiteboard v1.4.2:**
+  - **Factory-reset URL cleanup** — the cache-busting `?factoryReset=…` query param is removed from the URL after the post-reset reload so subsequent navigation / share isn't carrying a one-shot diagnostic flag.
+
+  IDB schema upgrades automatically from v4 → v5 (additive: new `shapes` store; existing strokes / images / texts data is untouched). The upgrade now surfaces the multi-tab-blocked case loudly via a console warning instead of hanging boot silently.
+
+### Notes
+
+- 📜 **TLDraw license reminder** — tldraw v5 (still bundled at the same version as v1.5.0) requires `TLDRAW_LICENSE_KEY` in `.env` for any deployment on a hostname OTHER than `localhost` / `127.0.0.1`. On non-localhost without a key, the tldraw canvas is blocked by a license-required overlay. A free WatermarkOnly key is available at [tldraw.dev/community/license](https://tldraw.dev/community/license); see [README.md → "TLDraw Licensing"](https://github.com/vppillai/diagram-tools-hub/blob/main/README.md#tldraw-licensing) for the full table of options. **The `.env.example` template now includes a commented `TLDRAW_LICENSE_KEY=` line** so the gap is harder to miss for new operators.
+
 ## [1.5.0] — 2026-05-14
 
 Submodule bump — picks up whiteboard `v1.1.0` → `v1.3.0` (skipping the v1.2.0 release; this DTH release rolls both whiteboard minors into a single deployment). The bundled `/whiteboard/` instance gains the entire v1.2 batch (text tool, dedicated Select tool, laser pointer, mouse synthetic pressure, idle / jiggle pen halo, double-Esc tool toggle) plus the v1.3 batch (Lasso → Select absorption with marquee + multi-select, whiteboard-native clipboard round-trip for strokes + texts). DTH proper is unchanged: same services, same networking, same env contract.

--- a/manage-config.sh
+++ b/manage-config.sh
@@ -756,7 +756,7 @@ services:
     restart: unless-stopped
 
   # Whiteboard - low-latency, pen-optimized whiteboard (vppillai/whiteboard)
-  # Source is a git submodule pinned at v1.3.0 (./whiteboard/).
+  # Source is a git submodule pinned at v1.4.2 (./whiteboard/).
   # Built with BASE_PATH=/whiteboard/ so assets are prefixed correctly for the
   # sub-path mount; nginx strips the prefix on proxy_pass.
   whiteboard:
@@ -840,7 +840,7 @@ services:
     restart: unless-stopped
 
   # Whiteboard - low-latency, pen-optimized whiteboard (vppillai/whiteboard)
-  # Source is a git submodule pinned at v1.3.0 (./whiteboard/).
+  # Source is a git submodule pinned at v1.4.2 (./whiteboard/).
   # Built with BASE_PATH=/whiteboard/ so assets are prefixed correctly for the
   # sub-path mount; nginx strips the prefix on proxy_pass.
   whiteboard:


### PR DESCRIPTION
## Summary

Submodule bump: whiteboard `v1.3.0` → `v1.4.2`. Picks up the v1.4 family (Shape tool + right-click menu overhaul + factory reset) plus the two follow-up patches (empty-text guard, factory-reset URL cleanup).

DTH proper is unchanged — same services, same networking, same env contract.

## What changes at `/whiteboard/`

- **Shape tool** — drag-to-create rect / ellipse / line / arrow (R/O/A/L). Sticky color, stroke width, fill toggle, fill-opacity slider. Round-trips through clipboard + PNG/SVG/PDF exports as native vector primitives. Endpoint-based resize for lines/arrows so dragging past origin flips direction naturally.
- **Right-click menu overhaul** — icon-only pills with hover tooltips revealing name + shortcut. Shared swatch palette (curated + custom + "+") across every COLOR section. Hover-revealed × badge deletes custom swatches inline. Pinned menu persists across browser sessions (localStorage), survives Esc, auto-rebuilds when settings change, and auto-reappears at its anchor on page refresh.
- **Factory Reset** in the settings panel — wipes all per-origin browser state (IDB / localStorage / caches / SWs) and reloads. Replaces the DevTools-console snippet that was the previous recovery path.
- **Block-eraser scope** — wipe mode stays strokes-only (pixel cuts); object mode tap deletes any kind. Prevents the prior "erasing strokes off an image also nukes the image" footgun.
- **Fine-grained text size** — Cmd/Ctrl+Shift+,/. for 1 px step. Works in both edit mode and Select mode.
- **Keymap rebinds** — R/O/A/L for shape sub-modes; P for laser (was L); Shift+P pen-default (was P); Shift+C color (was C); Shift+O options (was O).

Plus v1.4.1's empty-text guard and v1.4.2's factory-reset URL cleanup.

IDB upgrades v4 → v5 automatically (additive: new `shapes` store). Existing data is preserved.

## TLDraw license reminder

tldraw v5 still requires `TLDRAW_LICENSE_KEY` in `.env` for any deployment on a hostname OTHER than `localhost` / `127.0.0.1`. Non-localhost without a key = canvas blocked by license overlay. Free WatermarkOnly key at [tldraw.dev/community/license](https://tldraw.dev/community/license); see [README.md → "TLDraw Licensing"](https://github.com/vppillai/diagram-tools-hub/blob/main/README.md#tldraw-licensing). The `.env.example` template now includes a commented `TLDRAW_LICENSE_KEY=` line with inline instructions.

## Files changed

- `whiteboard` submodule → v1.4.2 (commit `8fc4f40`)
- `manage-config.sh` — "pinned at v1.3.0" → "pinned at v1.4.2" in two header comments
- `.env.example` — adds the commented `TLDRAW_LICENSE_KEY=` line + explainer
- `CHANGELOG.md` — v1.6.0 entry

## Test plan

- [ ] `./manage-config.sh start` brings up the stack cleanly
- [ ] `https://localhost:8080/whiteboard/` loads; new Shape tool visible
- [ ] Existing IDB data (boards from v1.5.0) loads after v4→v5 upgrade
- [ ] Right-click menu shows icon pills + custom swatch "+"
- [ ] Settings → Factory reset wipes state and reloads
- [ ] tldraw at `https://localhost:8080/tldraw/` still works (no behavior change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)