### PR TITLE
release: v1.6.1 — bump whiteboard submodule v1.4.2 → v1.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ For commit-level detail, see the auto-generated body of each
 
 ## [Unreleased]
 
+## [1.6.1] — 2026-05-15
+
+Submodule patch bump — picks up whiteboard `v1.4.2` → `v1.4.3`. Single-commit fix that defers a `clearFlow` reference in the tool menu so opening / restoring the menu doesn't trip a Temporal Dead Zone `ReferenceError`. The crash was reachable on first right-click after page load OR on the auto-reopen of a pinned menu after refresh. DTH proper is unchanged.
+
+### Fixed
+
+- **Whiteboard submodule bumped to [v1.4.3](https://github.com/vppillai/whiteboard/releases/tag/v1.4.3).** Pulls in the TDZ crash fix in the right-click tool menu — `clearFlow` is now read lazily inside the click handler instead of eagerly at menu-content build time, so it's never accessed before its `const` binding initializes.
+
 ## [1.6.0] — 2026-05-14
 
 Submodule bump — picks up whiteboard `v1.3.0` → `v1.4.2`. The bundled `/whiteboard/` instance gains the v1.4 Shape tool (rectangle / ellipse / line / arrow), a comprehensive right-click menu overhaul (icon-only pills with hover tooltips, shared swatch palette with custom-color "+" and ×-delete, pinned-menu persistence across sessions), a Factory Reset button in the settings panel (recovery from stuck IDB / service-worker states), plus two follow-up patches (empty-text guard, factory-reset URL cleanup). DTH proper is unchanged: same services, same networking, same env contract.

--- a/manage-config.sh
+++ b/manage-config.sh
@@ -756,7 +756,7 @@ services:
     restart: unless-stopped
 
   # Whiteboard - low-latency, pen-optimized whiteboard (vppillai/whiteboard)
-  # Source is a git submodule pinned at v1.4.2 (./whiteboard/).
+  # Source is a git submodule pinned at v1.4.3 (./whiteboard/).
   # Built with BASE_PATH=/whiteboard/ so assets are prefixed correctly for the
   # sub-path mount; nginx strips the prefix on proxy_pass.
   whiteboard:
@@ -840,7 +840,7 @@ services:
     restart: unless-stopped
 
   # Whiteboard - low-latency, pen-optimized whiteboard (vppillai/whiteboard)
-  # Source is a git submodule pinned at v1.4.2 (./whiteboard/).
+  # Source is a git submodule pinned at v1.4.3 (./whiteboard/).
   # Built with BASE_PATH=/whiteboard/ so assets are prefixed correctly for the
   # sub-path mount; nginx strips the prefix on proxy_pass.
   whiteboard:


### PR DESCRIPTION
## Summary

Patch-level submodule bump: whiteboard `v1.4.2` → `v1.4.3`. Single-commit fix in the whiteboard's right-click tool menu that resolves a TDZ (Temporal Dead Zone) crash when opening or auto-restoring the menu.

DTH proper is unchanged.

## What changes at `/whiteboard/`

- **Fixed**: opening the right-click tool menu (or having a pinned menu auto-reopen on page refresh) no longer trips `ReferenceError: Cannot access 'clearFlow' before initialization`. The `clearFlow` reference is now read lazily inside the click-handler closure instead of eagerly at menu-content build time, so it's only evaluated after its `const` binding has been assigned.

No new features. No env contract change. No schema change.

## Files changed

- `whiteboard` submodule → v1.4.3 (commit `141c0ae`)
- `manage-config.sh` — "pinned at v1.4.2" → "pinned at v1.4.3"
- `CHANGELOG.md` — v1.6.1 entry

## Test plan

- [ ] `./manage-config.sh start` brings up the stack cleanly
- [ ] `https://localhost:8080/whiteboard/` — right-click on canvas opens the tool menu without crash
- [ ] Pin the tool menu, refresh page — pinned menu auto-restores without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)